### PR TITLE
fix: show nix build instead of nix run

### DIFF
--- a/src/flake/run.go
+++ b/src/flake/run.go
@@ -18,27 +18,27 @@ type RunActionCmd struct {
 	Action string
 }
 
-func (c *RunActionCmd) Assemble(extraArgs []string) (string, string, []string, error) {
+func (c *RunActionCmd) Assemble(extraArgs []string) (string, []string, error) {
 	nix, err := getNix()
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, err
 	}
 
 	currentSystem, err := getCurrentSystem()
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, err
 	}
 
 	args, err := c.getArgs(currentSystem)
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, err
 	}
 
 	if extraArgs != nil && len(extraArgs) > 0 {
 		args = append(args, "--")
 		args = append(args, extraArgs...)
 	}
-	return nix, "run", args, nil
+	return nix, args, nil
 }
 
 func (c *RunActionCmd) Build(nix string, args, extraArgs []string) (string, []string, error) {
@@ -83,7 +83,7 @@ func (c *RunActionCmd) Build(nix string, args, extraArgs []string) (string, []st
 
 func (c *RunActionCmd) Exec(extraArgs []string) error {
 
-	nix, _, args, err := c.Assemble(nil)
+	nix, args, err := c.Assemble(nil)
 	if err != nil {
 		return err
 	}

--- a/src/tui.go
+++ b/src/tui.go
@@ -156,8 +156,8 @@ func (m *Tui) SetInspect() (tea.Model, tea.Cmd) {
 			Target: i.r.TargetName(i.CellIdx, i.BlockIdx, i.TargetIdx),
 			Action: i.r.ActionTitle(i.CellIdx, i.BlockIdx, i.TargetIdx, i.ActionIdx),
 		}
-		_, sub, args, _ := cmd.Assemble(nil)
-		m.InspectAction = "nix " + sub + " " + strings.Join(args, " \\\n")
+		_, args, _ := cmd.Assemble(nil)
+		m.InspectAction = "nix build " + strings.Join(args, " \\\n")
 		return m, nil
 	} else {
 		m.InspectAction = ""


### PR DESCRIPTION
`nix run` has special expectations towards the derivation (*/bin/<name>).

But we don't usually fulfill those expectations.

`nix build` is good enought for low level inspection.

fixes: #4
