### PR TITLE
fix: quote action invokations as they may contain '.'

### DIFF
--- a/src/flake/run.go
+++ b/src/flake/run.go
@@ -118,5 +118,5 @@ func (c *RunActionCmd) getArgs(currentSystem string) ([]string, error) {
 }
 
 func (c *RunActionCmd) renderFragmentFor(system string) string {
-	return tprintf(c, flakeRegistry(".")+".actions."+system+".{{.Cell}}.{{.Block}}.{{.Target}}.{{.Action}}")
+	return tprintf(c, "'"+flakeRegistry(".")+".actions."+system+".\"{{.Cell}}\".\"{{.Block}}\".\"{{.Target}}\".\"{{.Action}}\"'")
 }


### PR DESCRIPTION
# Context

Error:
```
does not provide attribute '__std.actions.x86_64-linux.cell.block.target@2.1.install'
```

i.e. Block ha not target `target@2` with attribute `1` but rather a target `target@2.1`

To signify that, nix requires quotes: `block."target@2.1"`.


# Solution

Add quotes everywhere we interpolate a string that could potentially contain a dot.
